### PR TITLE
feat: add multiple profiles endpoint

### DIFF
--- a/app/players/controllers/get_multiple_profiles_controller.py
+++ b/app/players/controllers/get_multiple_profiles_controller.py
@@ -1,0 +1,66 @@
+"""Multiple Profiles Controller module"""
+
+from typing import ClassVar
+
+from fastapi import Request, Response
+
+from app.config import settings
+from app.exceptions import ParserBlizzardError, ParserParsingError
+from app.helpers import overfast_internal_error
+from app.overfast_logger import logger
+
+from ..parsers.multiple_profiles_parser import MultipleProfilesParser
+
+
+class GetMultipleProfilesController:
+    """Multiple Profiles Controller used to retrieve condensed data for multiple
+    Overwatch player profiles efficiently. Returns endorsement level and season
+    data for multiple players in a single request.
+    
+    This controller bypasses caching to work without Redis setup.
+    """
+
+    parser_classes: ClassVar[list] = [MultipleProfilesParser]
+    timeout = settings.career_path_cache_timeout
+
+    def __init__(self, request: Request, response: Response):
+        self.request = request
+        self.response = response
+        # Grab the shared HTTPX AsyncClient from app.state
+        self.httpx_client = request.app.state.httpx_client
+
+    @classmethod
+    def get_human_readable_timeout(cls) -> str:
+        """Return human readable timeout for documentation"""
+        return f"{cls.timeout} seconds"
+
+    async def process_request(self, **kwargs) -> dict:
+        """
+        Main method to process request and return data.
+        
+        This version bypasses caching and directly processes the request.
+        """
+        logger.info("Processing multiple profiles request...")
+        
+        # Instantiate the parser
+        parser = MultipleProfilesParser(
+            httpx_client=self.httpx_client,
+            request=self.request,
+            response=self.response,
+            **kwargs
+        )
+
+        try:
+            # Parse the data
+            await parser.parse()
+        except ParserBlizzardError as error:
+            raise error  # Let the router handle HTTPException
+        except ParserParsingError as error:
+            raise overfast_internal_error("multiple profiles", error) from error
+
+        # Filter parser data if needed
+        logger.info("Filtering the data using query...")
+        computed_data = parser.filter_request_using_query(**kwargs)
+
+        logger.info("Done ! Returning filtered data...")
+        return computed_data

--- a/app/players/models.py
+++ b/app/players/models.py
@@ -85,7 +85,28 @@ class PlayerSearchResult(BaseModel):
     results: list[PlayerShort] = Field(..., description="List of players found")
 
 
-# Player career
+# Multiple profiles response
+class ProfileResponse(BaseModel):
+    """Condensed profile response for multiple profiles endpoint"""
+    endorsementLevel: int = Field(
+        ...,
+        description="Player endorsement level. 0 if no information found.",
+        examples=[3],
+        ge=0,
+        le=5,
+    )
+    season: int = Field(
+        ...,
+        description=(
+            "Last competitive season played by the player on PC. 0 if no information found "
+            "or if the player doesn't play competitive."
+        ),
+        examples=[13],
+        ge=0,
+    )
+
+
+# Rest of your existing models remain the same...
 class PlayerCompetitiveRank(BaseModel):
     division: CompetitiveDivision = Field(
         ...,

--- a/app/players/parsers/multiple_profiles_parser.py
+++ b/app/players/parsers/multiple_profiles_parser.py
@@ -1,0 +1,105 @@
+"""Multiple Profiles Parser module"""
+
+from fastapi import HTTPException, status
+
+from app.overfast_logger import logger
+from app.parsers import AbstractParser
+
+from ..controllers.get_player_career_controller import GetPlayerCareerController
+
+
+class MultipleProfilesParser(AbstractParser):
+    """Parser for retrieving multiple Overwatch player profiles in condensed format.
+    
+    This parser orchestrates multiple calls to the existing player career system
+    to efficiently gather endorsement level and PC season data for multiple players.
+    Bypasses caching for AWS Lambda deployment.
+    """
+
+    def __init__(self, httpx_client, **kwargs):
+        super().__init__(**kwargs)
+        self.httpx_client = httpx_client
+        self.request = kwargs.get("request")
+        self.response = kwargs.get("response")
+        self.player_ids = kwargs.get("player_ids", [])
+
+    async def parse(self) -> None:
+        """Parse multiple player profiles and extract condensed data."""
+        logger.info(f"Retrieving profiles for {len(self.player_ids)} players...")
+        
+        results = {}
+        missing_players = []
+
+        for player_id in self.player_ids:
+            try:
+                logger.debug(f"Processing player: {player_id}")
+                
+                # Use the existing GetPlayerCareerController to get player summary
+                controller = GetPlayerCareerController(self.request, self.response)
+                player_data = await controller.process_request(
+                    summary=True,
+                    player_id=player_id,
+                )
+
+                # Extract endorsement level
+                endorsement_level = self._extract_endorsement_level(player_data)
+                if endorsement_level is None:
+                    logger.warning(f"Could not extract endorsement level for {player_id}")
+                    missing_players.append(player_id)
+                    continue
+
+                # Extract PC season information only
+                season = self._extract_pc_season(player_data)
+
+                results[player_id] = {
+                    "endorsementLevel": endorsement_level,
+                    "season": season,
+                }
+
+            except HTTPException as e:
+                if e.status_code == status.HTTP_404_NOT_FOUND:
+                    logger.warning(f"Player not found: {player_id}")
+                    missing_players.append(player_id)
+                else:
+                    # Re-raise other HTTP exceptions
+                    raise
+
+        # If any players are missing, raise 404 with details
+        if missing_players:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"error": f"Profiles not found: {', '.join(missing_players)}"},
+            )
+
+        self.data = results
+        logger.info(f"Successfully retrieved {len(results)} profiles")
+
+    def _extract_endorsement_level(self, player_data: dict) -> int | None:
+        """Extract endorsement level from player data."""
+        endorsement = player_data.get("endorsement")
+        if not endorsement:
+            return None
+        
+        level = endorsement.get("level")
+        return level if level is not None else None
+
+    def _extract_pc_season(self, player_data: dict) -> int:
+        """Extract the PC competitive season from player data.
+        
+        Only checks PC platform as requested. Returns 0 if no competitive data.
+        """
+        competitive = player_data.get("competitive")
+        if not competitive:
+            return 0
+
+        # Only check PC platform
+        pc_data = competitive.get("pc")
+        if pc_data and pc_data.get("season") is not None:
+            return pc_data["season"]
+
+        # Return 0 if no PC competitive data
+        return 0
+
+    def filter_request_using_query(self, **kwargs) -> dict:
+        """Return the parsed data as-is since no filtering is needed."""
+        return self.data

--- a/app/players/router.py
+++ b/app/players/router.py
@@ -1,12 +1,13 @@
 """Players endpoints router : players search, players career, statistics, etc."""
 
-from typing import Annotated
+from typing import Dict, Annotated
 
-from fastapi import APIRouter, Depends, Path, Query, Request, Response, status
+from fastapi import APIRouter, Depends, Path, Query, Request, Response, HTTPException, status
 
 from app.enums import RouteTag
 from app.helpers import routes_responses as common_routes_responses
 
+from .controllers.get_multiple_profiles_controller import GetMultipleProfilesController
 from .controllers.get_player_career_controller import GetPlayerCareerController
 from .controllers.get_player_career_stats_controller import (
     GetPlayerCareerStatsController,
@@ -28,6 +29,7 @@ from .models import (
     PlayerSearchResult,
     PlayerStatsSummary,
     PlayerSummary,
+    ProfileResponse,
 )
 
 # Custom route responses for player careers
@@ -35,6 +37,19 @@ career_routes_responses = {
     status.HTTP_404_NOT_FOUND: {
         "model": PlayerParserErrorMessage,
         "description": "Player Not Found",
+    },
+    **common_routes_responses,
+}
+
+# Custom route responses for multiple profiles
+multiple_profiles_responses = {
+    status.HTTP_404_NOT_FOUND: {
+        "model": PlayerParserErrorMessage,
+        "description": "One or more profiles not found",
+    },
+    status.HTTP_422_UNPROCESSABLE_ENTITY: {
+        "model": PlayerParserErrorMessage,
+        "description": "Invalid input parameters",
     },
     **common_routes_responses,
 }
@@ -93,6 +108,32 @@ async def get_player_career_common_parameters(
 
 CommonsPlayerCareerDep = Annotated[dict, Depends(get_player_career_common_parameters)]
 
+
+def validate_player_ids(ids: str) -> list[str]:
+    """Validate and parse comma-separated player IDs."""
+    if not ids.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"error": "`ids` is required and must not be empty."}
+        )
+    
+    player_ids = [player_id.strip() for player_id in ids.split(",") if player_id.strip()]
+    
+    if not player_ids:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"error": "No valid BattleTags provided."}
+        )
+    
+    if len(player_ids) > 20:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"error": "Too many player IDs. Maximum 20 allowed per request."}
+        )
+    
+    return player_ids
+
+
 router = APIRouter()
 
 
@@ -134,6 +175,43 @@ async def search_players(
         order_by=order_by,
         offset=offset,
         limit=limit,
+    )
+
+
+@router.get(
+    "/overwatch/profile",
+    responses=multiple_profiles_responses,
+    tags=[RouteTag.PLAYERS],
+    summary="Get multiple Overwatch profiles (condensed)",
+    description=(
+        "Returns condensed profile data for multiple players in a single request. "
+        "This endpoint is optimized for overlay applications that need basic profile "
+        "information (endorsement level and PC competitive season) for multiple players efficiently. "
+        "<br />Query parameter `ids` must be a comma-separated list of BattleTags (use `-` instead of `#`). "
+        "<br />**Note:** This endpoint is protected by API Gateway authentication. "
+        "<br />**Maximum 20 players per request.**"
+    ),
+    response_model=Dict[str, ProfileResponse],
+    operation_id="get_multiple_profiles",
+)
+async def get_multiple_profiles(
+    request: Request,
+    response: Response,
+    ids: Annotated[
+        str,
+        Query(
+            ...,
+            description="Comma-separated BattleTags, e.g. `TeKrop-2217,ikyola-1482`",
+            examples=["TeKrop-2217,ikyola-1482"],
+        ),
+    ],
+) -> Dict[str, ProfileResponse]:
+    # Validate and parse player IDs
+    player_ids = validate_player_ids(ids)
+    
+    # Use the controller to process the request
+    return await GetMultipleProfilesController(request, response).process_request(
+        player_ids=player_ids,
     )
 
 


### PR DESCRIPTION
## Summary 
Added a new `/players/overwatch/profile` endpoint that returns condensed profile data for multiple players in a single request. 

## API Usage
```bash
GET /players/overwatch/profile?ids=TeKrop-2217,ikyola-1482

{
  "TeKrop-2217": {
    "endorsementLevel": 2,
    "season": 13
  },
  "ikyola-1482": {
    "endorsementLevel": 1,
    "season": 12
  }
}

```