### PR TITLE
Add overwatch maps endpoint

### DIFF
--- a/app/maps/controllers/get_overwatch_maps_controller.py
+++ b/app/maps/controllers/get_overwatch_maps_controller.py
@@ -1,0 +1,61 @@
+"""Overwatch Maps Controller module"""
+
+from typing import ClassVar
+
+from fastapi import Request, Response
+
+from app.config import settings
+from app.exceptions import ParserBlizzardError, ParserParsingError
+from app.helpers import overfast_internal_error
+from app.overfast_logger import logger
+
+from ..parsers.overwatch_maps_parser import OverwatchMapsParser
+
+
+class GetOverwatchMapsController:
+    """Overwatch Maps Controller used to retrieve a simplified list of
+    Overwatch maps for overlay applications. Returns only name and screenshot
+    data optimized for Overwolf apps.
+    
+    This controller bypasses caching to work without Redis setup.
+    """
+
+    parser_classes: ClassVar[list] = [OverwatchMapsParser]
+    timeout = settings.csv_cache_timeout
+
+    def __init__(self, request: Request, response: Response):
+        self.request = request
+        self.response = response
+        # Grab the shared HTTPX AsyncClient from app.state (not needed for CSV but consistent)
+        self.httpx_client = request.app.state.httpx_client
+
+    @classmethod
+    def get_human_readable_timeout(cls) -> str:
+        """Return human readable timeout for documentation"""
+        return f"{cls.timeout} seconds"
+
+    async def process_request(self, **kwargs) -> list[dict]:
+        """
+        Main method to process request and return data.
+        
+        This version bypasses caching and directly processes the request.
+        """
+        logger.info("Processing Overwatch maps request...")
+        
+        # Instantiate the parser
+        parser = OverwatchMapsParser(**kwargs)
+
+        try:
+            # Parse the data
+            await parser.parse()
+        except ParserBlizzardError as error:
+            raise error  # Let the router handle HTTPException
+        except ParserParsingError as error:
+            raise overfast_internal_error("overwatch maps", error) from error
+
+        # Filter parser data if needed
+        logger.info("Filtering the data using query...")
+        computed_data = parser.filter_request_using_query(**kwargs)
+
+        logger.info("Done ! Returning filtered data...")
+        return computed_data

--- a/app/maps/models.py
+++ b/app/maps/models.py
@@ -30,3 +30,16 @@ class Map(BaseModel):
         ),
         examples=["JP"],
     )
+
+class OverwatchMap(BaseModel):
+    """Simplified map model for Overwolf application"""
+    name: str = Field(
+        ..., 
+        description="Name of the map", 
+        examples=["Hanamura"]
+    )
+    screenshot: HttpUrl = Field(
+        ...,
+        description="CDN URL of the map screenshot",
+        examples=["https://overfast-api.tekrop.fr/static/maps/hanamura.jpg"],
+    )

--- a/app/maps/parsers/overwatch_maps_parser.py
+++ b/app/maps/parsers/overwatch_maps_parser.py
@@ -1,0 +1,32 @@
+"""Overwatch Maps Parser module"""
+
+from app.overfast_logger import logger
+from app.parsers import CSVParser
+
+
+class OverwatchMapsParser(CSVParser):
+    """Overwatch maps parser for simplified map data.
+    
+    Returns only name and screenshot for overlay applications,
+    optimized for Overwolf integration.
+    """
+
+    filename = "maps"
+
+    def parse_data(self) -> list[dict]:
+        """Parse CSV data and return simplified map structure."""
+        logger.info("Parsing maps data for Overwolf...")
+        
+        simplified_maps = []
+        for map_dict in self.csv_data:
+            simplified_maps.append({
+                "name": map_dict["name"],
+                "screenshot": self.get_static_url(map_dict["key"]),
+            })
+        
+        logger.info(f"Parsed {len(simplified_maps)} maps")
+        return simplified_maps
+
+    def filter_request_using_query(self, **kwargs) -> list[dict]:
+        """Return all maps data as-is since no filtering is needed for this endpoint."""
+        return self.data

--- a/app/maps/router.py
+++ b/app/maps/router.py
@@ -8,8 +8,9 @@ from app.enums import RouteTag
 from app.gamemodes.enums import MapGamemode
 from app.helpers import success_responses
 
+from .controllers.get_overwatch_maps_controller import GetOverwatchMapsController
 from .controllers.list_maps_controller import ListMapsController
-from .models import Map
+from .models import Map, OverwatchMap
 
 router = APIRouter()
 
@@ -39,3 +40,25 @@ async def list_maps(
     return await ListMapsController(request, response).process_request(
         gamemode=gamemode
     )
+
+
+@router.get(
+    "/overwatch/maps",
+    responses=success_responses,
+    tags=[RouteTag.MAPS],
+    summary="Get Overwatch maps (simplified)",
+    description=(
+        "Get a simplified list of Overwatch maps with only name and screenshot. "
+        "This endpoint is optimized for overlay applications that need basic map "
+        "information with CDN image URLs for display purposes. "
+        "<br />**Note:** This endpoint is protected by API Gateway authentication. "
+    ),
+    response_model=list[OverwatchMap],
+    operation_id="get_overwatch_maps",
+)
+async def get_overwatch_maps(
+    request: Request,
+    response: Response,
+) -> list[OverwatchMap]:
+    """Get simplified maps data for Overwolf overlay application."""
+    return await GetOverwatchMapsController(request, response).process_request()


### PR DESCRIPTION
# Summary
Added a new `/overwatch/maps` endpoint that returns simplified map data. Only includes name and CDN screenshot URLs for efficient display.

## New Endpoint
**URL:** `/overwatch/maps`  
**Response:**
```json
[
  {
    "name": "Hanamura",
    "screenshot": "https://overfast-api.tekrop.fr/static/maps/hanamura.jpg"
  },
  {
    "name": "King's Row", 
    "screenshot": "https://overfast-api.tekrop.fr/static/maps/kings-row.jpg"
  }
]